### PR TITLE
fixed abort when position_lat / long = none

### DIFF
--- a/src/fit2gpx.py
+++ b/src/fit2gpx.py
@@ -81,8 +81,19 @@ class Converter:
             # Frame lat or long is None. Ignore frame
             return None
         else:
-            data['latitude'] = frame.get_value('position_lat') / ((2 ** 32) / 360)
-            data['longitude'] = frame.get_value('position_long') / ((2 ** 32) / 360)
+            position_lat = frame.get_value('position_lat')
+            if position_lat is not None:
+                data['latitude'] = position_lat / ((2 ** 32) / 360)
+            else:
+                data['latitude'] = 0.0
+                pass
+            position_long = frame.get_value('position_long')
+            if position_lat is not None:
+                data['longitude'] = frame.get_value('position_long') / ((2 ** 32) / 360)
+            else:
+                data['longitude'] = 0.0
+                pass
+            
 
         # Step 2: Extract all other fields
         for field in self._colnames_points[3:]:


### PR DESCRIPTION
When position_lat or position_long is "None" the script would abort. now the value is set to 0.0.

I ran into this problem while my GPS-Device had an Hardware issue, and i couldn't combine these files. Now these files work as they should.