### PR TITLE
Fix pandas FutureWarning in fit_to_gpx method

### DIFF
--- a/src/fit2gpx.py
+++ b/src/fit2gpx.py
@@ -210,7 +210,7 @@ class Converter:
         enhanced_fields = ['altitude', 'speed']
         for field in enhanced_fields:
             if df_points[field].count() == 0 and df_points[f'enhanced_{field}'].count() > 0:
-                df_points[field].fillna(df_points[f'enhanced_{field}'], inplace=True)
+                df_points[field] = df_points[field].fillna(df_points[f'enhanced_{field}'])
 
         # Step 3: Convert pd.DataFrame to GPX
         gpx = self.dataframe_to_gpx(


### PR DESCRIPTION
This pull request addresses a FutureWarning raised when using `pandas.fillna` with `inplace=True` in the `fit_to_gpx` method. 
The change updates the method to use explicit assignment, making it compatible with current and future versions of Pandas.

Tested locally and verified that the warning is resolved and functionality remains intact.