### PR TITLE
Add support for batch and Strava conversion to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ And then you can run the `fit2gpx` command to convert a FIT file to GPX:
 fit2gpx 3323369944.fit 3323369944.gpx
 ```
 
+Or convert a Strava export directory to a directory of GPX files:
+
+```shell
+fit2gpx export_23749537 export_23749537_gpx
+```
+
 You can also read the FIT file from standard input and/or write the GPX file to
 standard output:
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ And then you can run the `fit2gpx` command to convert a FIT file to GPX:
 fit2gpx 3323369944.fit 3323369944.gpx
 ```
 
+Or convert a directory of FIT files to a directory of GPX files:
+
+```shell
+fit2gpx ./project/activities ./project/activities_convert
+```
+
 Or convert a Strava export directory to a directory of GPX files:
 
 ```shell

--- a/src/fit2gpx.py
+++ b/src/fit2gpx.py
@@ -494,7 +494,7 @@ def cli():
     )
     parser.add_argument(
         'infile',
-        help='path to the input .FIT file or Strava export directory; '
+        help='path to the input .FIT file, directory of .FIT files, or Strava export directory; '
         "use '-' to read the file from standard input",
     )
     parser.add_argument(
@@ -504,11 +504,14 @@ def cli():
     )
     args = parser.parse_args()
 
-    if os.path.isdir(args.infile):
-        strava_conv = StravaConverter(args.infile, args.outfile)
+    if os.path.isdir(os.path.join(args.infile, 'activities')):
+        strava_conv = StravaConverter(dir_in=args.infile, dir_out=args.outfile)
         strava_conv.unzip_activities()
         strava_conv.add_metadata_to_gpx()
         strava_conv.strava_fit_to_gpx()
+    elif os.path.isdir(args.infile):
+        conv = Converter()
+        conv.fit_to_gpx_bulk(dir_in=args.infile, dir_out=args.outfile)
     else:
         conv = Converter()
         conv.fit_to_gpx(


### PR DESCRIPTION
### Motivation

Add support to the CLI for:

- Use case 2.2: convert many FIT files to GPX files
- Use case 3: Strava Bulk Export Tools (FIT to GPX conversion)

Related: https://github.com/dodo-saba/fit2gpx/pull/9

### Changes

Choose the correct use case automatically:

- If the CLI argument is a directory with an `activities/` subdirectory, then treat it as a Strava export.
- If the CLI argument is a directory **without** an `activities/` subdirectory, then treat it as a directory of FIT files.
- Else do a single FIT to GPX conversion.

### Testing

Convert a directory of FIT files:

```shell
fit2gpx ./project/activities ./project/activities_convert
```

Convert a Strava export directory:

```shell
fit2gpx export_23749537 export_23749537_gpx
```

See the updated README.